### PR TITLE
Don't use hardcoded yarn path

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,5 +5,3 @@ nodeLinker: node-modules
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: "@yarnpkg/plugin-interactive-tools"
-
-yarnPath: .yarn/releases/yarn-3.3.1.cjs


### PR DESCRIPTION
The yarn config had leftover entry for hardcoded path, which is not needed as docker image already contains the latest yarn 