### PR TITLE
IPv6 and networking fixes

### DIFF
--- a/app/components/liquid_address_component.rb
+++ b/app/components/liquid_address_component.rb
@@ -3,11 +3,6 @@
 class LiquidAddressComponent < LiquidTooltipSnippetComponent
   with_collection_parameter :object
 
-  def initialize(object:, net_only: false)
-    @object = object
-    @net_only = net_only
-  end
-
   def render?
     @object
   end
@@ -16,7 +11,6 @@ class LiquidAddressComponent < LiquidTooltipSnippetComponent
     def template_text
       calc = UnsubstitutedAddress.new(@object)
       text = AddressValues.result_for(@object) || calc.send(:result)
-      return text unless @net_only
 
       case text
       when /::/

--- a/app/components/liquid_network_address_component.rb
+++ b/app/components/liquid_network_address_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class LiquidNetworkAddressComponent < LiquidTooltipSnippetComponent
+  with_collection_parameter :object
+
+  def render?
+    @object
+  end
+
+  private
+    def template_text
+      @object.network_address.gsub(/\/\d+\z/, '')
+    end
+end

--- a/app/forms/address_pool_form.rb
+++ b/app/forms/address_pool_form.rb
@@ -40,12 +40,16 @@ class AddressPoolForm < Patterns::Form
   end
 
   def gateway6
-    return unless resource.ip_v6?
-    Ipv6Offset.load(attributes[:gateway]).to_s
+    return if !resource.ip_v6? || attributes[:gateway].nil?
+    Ipv6Offset.load(attributes[:gateway]).to_s.presence || "0"
   end
 
   def gateway6=(input)
-    self.gateway = Ipv6Offset.dump(input)
+    self.gateway = if input.blank?
+      nil
+    else
+      Ipv6Offset.dump(input)
+    end
   rescue
     self.gateway = resource.gateway
   end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -89,7 +89,7 @@ class Address < ApplicationRecord
     when 'ipv4_static', 'ipv4_vip', 'ipv6_static', 'ipv6_vip'
       address_pool.network_address
     when 'ipv6_linklocal'
-      'fe80::/10'
+      'fe80::/64'
     when 'ipv6_uniqlocal'
       'fc00::/7'
     end

--- a/app/models/address_pool.rb
+++ b/app/models/address_pool.rb
@@ -49,6 +49,7 @@ class AddressPool < ApplicationRecord
   end
 
   def gateway_address_object
+    return if gateway.blank?
     Address.new(
       mode: address_mode,
       address_pool: self,

--- a/app/presenters/api/v3/network_instance_presenter.rb
+++ b/app/presenters/api/v3/network_instance_presenter.rb
@@ -15,7 +15,7 @@ module API
               id: pool.slug,
               ip_family: pool.ip_family,
               network_address: substitute(pool.network_address),
-              gateway: pool.gateway_address_object.ip_object(nil, team_number).to_s
+              gateway: pool.gateway_address_object&.ip_object(nil, team_number)&.to_s
             }
           end,
           config_map: network.config_map&.deep_transform_values do |value|

--- a/app/views/address_pools/_address_pool.html.haml
+++ b/app/views/address_pools/_address_pool.html.haml
@@ -51,7 +51,7 @@
             = form.label :gateway, class: 'block font-bold text-gray-700 dark:text-gray-200'
             .mt-1.flex.rounded-md.shadow-sm
               %span.inline-flex.items-center.px-3.rounded-l-md.border.border-r-0.border-gray-300.bg-gray-50.text-gray-500.dark:bg-gray-600.dark:text-current.dark:border-black.text-sm
-                = render LiquidAddressComponent.new(object: address_pool.gateway_address_object, net_only: true)
+                = render LiquidNetworkAddressComponent.new(object: address_pool)
               = form.text_field :gateway6, class: 'focus:ring-indigo-500 focus:border-indigo-500 flex-1 block w-full rounded-none border-gray-300 dark:bg-gray-500 dark:border-black'
               %span.inline-flex.items-center.px-3.rounded-r-md.border.border-l-0.border-gray-300.bg-gray-50.text-gray-500.dark:bg-gray-600.dark:text-current.dark:border-black.text-sm<>
                 = "/#{address_pool.ip_network.prefix}"

--- a/app/views/addresses/_address.html.haml
+++ b/app/views/addresses/_address.html.haml
@@ -48,7 +48,7 @@
         - if address.mode_ipv6_uniqlocal? || address.mode_ipv6_linklocal? || address.address_pool&.ip_network.present?
           .flex.rounded-md.shadow-sm.grow
             %span.inline-flex.items-center.px-3.rounded-l-md.border.border-r-0.border-gray-300.bg-gray-50.text-gray-500.dark:bg-gray-600.dark:text-current.dark:border-black.text-sm
-              = render LiquidAddressComponent.new(object: address, net_only: true)
+              = render LiquidNetworkAddressComponent.new(object: address.address_pool)
             = form.text_field :parsed_ipv6, class: 'focus:ring-indigo-500 focus:border-indigo-500 flex-1 block w-full sm:text-sm border-gray-300 dark:bg-gray-500 dark:border-black', autocomplete: "off"
             %span.inline-flex.items-center.px-3.rounded-r-md.border.border-l-0.border-gray-300.bg-gray-50.text-gray-500.dark:bg-gray-600.dark:text-current.dark:border-black.text-sm<
               = "/#{address.ip_family_network&.prefix}"

--- a/lib/ipv6_offset.rb
+++ b/lib/ipv6_offset.rb
@@ -11,10 +11,6 @@ class Ipv6Offset
       .sub(/^::/, '')
   end
 
-  def store_value
-    offset.zero? ? nil : offset
-  end
-
   def to_s
     @hex
   end
@@ -28,10 +24,10 @@ class Ipv6Offset
   class << self
     def dump(obj)
       return unless obj
-      offset = self.new(IPAddress("::#{obj}").to_u128) if obj.is_a?(String)
-      offset = self.new(obj) if obj.is_a?(Integer)
-      offset = obj if obj.is_a?(self)
-      offset.store_value
+      new_obj = self.new(IPAddress("::#{obj}").to_u128) if obj.is_a?(String)
+      new_obj = self.new(obj) if obj.is_a?(Integer)
+      new_obj = obj if obj.is_a?(self)
+      new_obj.offset
     end
 
     def load(obj)


### PR DESCRIPTION
Fixes handling of blank and 0 IPv6 offsets. Now blank values (such as gateway form field, if there is none) show as empty and offset 0 (all zeroes after ::) will show as "0" to make it clear there is a set value.

Secondly, this includes a refactor of LiquidAddressComponent and it's net_only mode to its own component.