### PR TITLE
Remove archived results from global search

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -6,9 +6,19 @@ class SearchesController < ApplicationController
   def create
     if params[:query].present?
       @results = [
-        policy_scope(VirtualMachine).search(params[:query]).limit(5),
-        policy_scope(Network).search(params[:query]).limit(5),
-        policy_scope(OperatingSystem).search(params[:query]).limit(5),
+        policy_scope(VirtualMachine)
+          .joins(:exercise)
+          .merge(Exercise.active)
+          .search(params[:query])
+          .limit(5),
+        policy_scope(Network)
+          .joins(:exercise)
+          .merge(Exercise.active)
+          .search(params[:query])
+          .limit(5),
+        policy_scope(OperatingSystem)
+          .search(params[:query])
+          .limit(5),
       ].flatten
     else
       @results = []


### PR DESCRIPTION
Currently, archived exercises/environments show up in global search, which is often not required. This limits the search scope to currently active environments
