### PR TITLE
fix: AddressPool update from new state

### DIFF
--- a/app/models/address_pool.rb
+++ b/app/models/address_pool.rb
@@ -117,7 +117,7 @@ class AddressPool < ApplicationRecord
     end
 
     def clear_dangling_ipv4_gateway
-      return if !gateway
+      return if !gateway || network_address_was.blank?
 
       all_hosts = available_range.map(&:to_u32).to_set
       previous_gateway = ip_network(nil, network_address_was.dup).allocate(gateway)


### PR DESCRIPTION
New `AddressPool`s have network_address field empty, which cannot be used to calculate "previous" gateway address.
Skip clearing dangling gateway in this case

Closes #25
