### PR TITLE
feat: Add single node clustering support

### DIFF
--- a/app/calculation/generate_tags.rb
+++ b/app/calculation/generate_tags.rb
@@ -122,7 +122,7 @@ class GenerateTags < Patterns::Calculation
     end
 
     def spec_result
-      many_items = subject.virtual_machine.custom_instance_count.to_i > 1 || subject.virtual_machine.numbered_actor
+      many_items = subject.virtual_machine.clustered? || subject.virtual_machine.numbered_actor
       subject.tag_list.map do |custom_tag|
         {
           id: "custom_#{custom_tag}",

--- a/app/calculation/hostname_generator.rb
+++ b/app/calculation/hostname_generator.rb
@@ -3,7 +3,7 @@
 class HostnameGenerator < Patterns::Calculation
   private
     def result
-      hostname_sequence_suffix = '{{ seq }}' if virtual_machine.custom_instance_count.to_i > 1
+      hostname_sequence_suffix = '{{ seq }}' if virtual_machine.clustered?
       hostname_team_suffix = '{{ team_nr_str }}' if virtual_machine.numbered_actor && (!nic || !nic.network&.numbered?)
 
       sequences = [

--- a/app/models/virtual_machine.rb
+++ b/app/models/virtual_machine.rb
@@ -94,6 +94,10 @@ class VirtualMachine < ApplicationRecord
     numbered_actor.presence&.number || 1
   end
 
+  def clustered?
+    custom_instance_count.to_i > 0
+  end
+
   private
     def lowercase_fields
       name.downcase! if name

--- a/app/presenters/api/v3/customization_spec_presenter.rb
+++ b/app/presenters/api/v3/customization_spec_presenter.rb
@@ -86,7 +86,7 @@ module API
         end
 
         def sequence_info
-          if vm.custom_instance_count.to_i > 1
+          if vm.clustered?
             {
               sequence_tag: spec.slug.tr('-', '_'),
               sequence_total: vm.custom_instance_count

--- a/app/presenters/api/v3/instance_presenter.rb
+++ b/app/presenters/api/v3/instance_presenter.rb
@@ -75,13 +75,13 @@ module API
         end
 
         def sequence_info
-          return {} unless vm.custom_instance_count.to_i > 1
+          return {} unless vm.clustered?
 
           { sequence_index: sequential_number }
         end
 
         def hostname_sequence_suffix
-          '{{ seq }}' if vm.custom_instance_count.to_i > 1
+          '{{ seq }}' if vm.clustered?
         end
 
         def hostname_team_suffix

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -52,7 +52,7 @@ FactoryBot.define do
 
   factory :operating_system do
     name { Faker::Computer.os }
-    cloud_id { name.to_url }
+    cloud_id { name.to_url+rand(999).to_s }
 
     cpu { 2 }
     ram { 4 }

--- a/spec/presenters/customization_spec_presenter_spec.rb
+++ b/spec/presenters/customization_spec_presenter_spec.rb
@@ -30,4 +30,29 @@ RSpec.describe API::V3::CustomizationSpecPresenter do
       end
     end
   end
+
+  context 'clustered vm' do
+    it 'return nil fields if not clustered' do
+      expect(subject[:sequence_tag]).to be_nil
+      expect(subject[:sequence_total]).to be_nil
+    end
+
+    context 'with custom instance count = 1' do
+      let(:spec) { create(:customization_spec, virtual_machine: create(:virtual_machine, custom_instance_count: 1)) }
+
+      it 'return nil fields' do
+        expect(subject[:sequence_tag]).to eq spec.slug.to_url.tr('-', '_')
+        expect(subject[:sequence_total]).to eq 1
+      end
+    end
+
+    context 'with custom instance count = 2' do
+      let(:spec) { create(:customization_spec, virtual_machine: create(:virtual_machine, custom_instance_count: 2)) }
+
+      it 'return nil fields' do
+        expect(subject[:sequence_tag]).to eq spec.slug.to_url.tr('-', '_')
+        expect(subject[:sequence_total]).to eq 2
+      end
+    end
+  end
 end


### PR DESCRIPTION
By using custom_instance_count field we can do flexible clustering on ansible side by also supporting 1 as count
