### PR TITLE
Add all_specs tag for VM-s

### DIFF
--- a/app/calculation/generate_tags.rb
+++ b/app/calculation/generate_tags.rb
@@ -11,7 +11,7 @@ class GenerateTags < Patterns::Calculation
       when Network
         network_result
       when VirtualMachine
-        virtual_machine_result || []
+        virtual_machine_result
       when CustomizationSpec
         spec_result
       when Capability
@@ -112,13 +112,26 @@ class GenerateTags < Patterns::Calculation
     end
 
     def virtual_machine_result
-      return unless subject.numbered_actor && !subject.numbered_actor.subtree.include?(subject.actor)
-      [{
-        id: ActorAPIName.result_for(subject.actor, numbered_by: subject.numbered_actor),
-        name: ActorAPIName.result_for(subject.actor, numbered_by: subject.numbered_actor),
-        config_map: {},
-        children: []
-      }]
+      [].tap do |results|
+        if subject.numbered_actor && !subject.numbered_actor.subtree.include?(subject.actor)
+          results << {
+            id: ActorAPIName.result_for(subject.actor, numbered_by: subject.numbered_actor),
+            name: ActorAPIName.result_for(subject.actor, numbered_by: subject.numbered_actor),
+            config_map: {},
+            children: []
+          }
+        end
+
+        if subject.customization_specs.size > 1
+          results << {
+            id: "#{subject.name}_all_specs",
+            name: "All specs for #{subject.name}",
+            config_map: {},
+            children: [],
+            priority: 95
+          }
+        end
+      end
     end
 
     def spec_result

--- a/spec/calculations/generate_tags_spec.rb
+++ b/spec/calculations/generate_tags_spec.rb
@@ -70,6 +70,27 @@ RSpec.describe GenerateTags do
     it { is_expected.to eq([default_result]) }
   end
 
+  context 'for VM' do
+    let(:source_objects) { [virtual_machine] }
+    let(:virtual_machine) { build(:virtual_machine) }
+
+    context 'which has multiple specs' do
+      let!(:customization_spec) { virtual_machine.customization_specs << build(:customization_spec, virtual_machine:) }
+      let!(:container_customization_spec) { virtual_machine.customization_specs << build(:customization_spec, virtual_machine:, mode: :container) }
+      let(:result) {
+        {
+          id: "#{virtual_machine.name}_all_specs",
+          name: "All specs for #{virtual_machine.name}",
+          config_map: {},
+          children: [],
+          priority: 95
+        }
+      }
+
+      it { is_expected.to include(result) }
+    end
+  end
+
   context 'for customization specs' do
     let(:source_objects) { [customization_spec] }
     let(:customization_spec) { build(:customization_spec) }
@@ -92,7 +113,6 @@ RSpec.describe GenerateTags do
 
       it { is_expected.to eq(result) }
     end
-
 
     context 'overarching group of all instances (sequential)' do
       let(:customization_spec) { create(:customization_spec, virtual_machine:) }

--- a/spec/presenters/customization_spec_presenter_spec.rb
+++ b/spec/presenters/customization_spec_presenter_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe API::V3::CustomizationSpecPresenter do
   subject { described_class.new(spec).as_json }
-  let(:spec) { create(:customization_spec) }
+  let(:virtual_machine) { create(:virtual_machine) }
+  let(:spec) { virtual_machine.host_spec }
 
   context 'tags' do
     it 'should contain OS and actor tags' do
@@ -15,10 +16,9 @@ RSpec.describe API::V3::CustomizationSpecPresenter do
     end
 
     context 'with nested os and actor' do
+      let(:virtual_machine) { create(:virtual_machine, operating_system:, actor:) }
       let(:actor) { create(:actor, parent: create(:actor)) }
       let(:operating_system) { create(:operating_system, parent: create(:operating_system)) }
-      let(:virtual_machine) { create(:virtual_machine, operating_system:, actor:) }
-      let(:spec) { create(:customization_spec, virtual_machine:) }
 
       it 'should contain entire paths for both' do
         expect(subject[:tags]).to eq([


### PR DESCRIPTION
This makes it easier to have group variables in Ansible that target the host and all it's specs