### PR TITLE
Instance metadata

### DIFF
--- a/app/controllers/api/v3/customization_specs_controller.rb
+++ b/app/controllers/api/v3/customization_specs_controller.rb
@@ -13,7 +13,7 @@ module API
 
       def show
         render json: {
-          result: CustomizationSpecPresenter.new(spec)
+          result: CustomizationSpecPresenter.new(spec, include_metadata: true)
         }
       rescue ActiveRecord::RecordNotFound
         render_not_found

--- a/app/controllers/api/v3/instances_controller.rb
+++ b/app/controllers/api/v3/instances_controller.rb
@@ -6,7 +6,7 @@ module API
       before_action :get_exercise, :authorize_spec, :validate_id, :validate_params
 
       def update
-        datum = spec.instance_metadata.first_or_create(instance: params[:id])
+        datum = spec.instance_metadata.where(instance: params[:id]).first_or_create
         if datum && datum.update(
           metadata: if request.patch?
                       datum.metadata.merge(metadata_param)
@@ -48,7 +48,7 @@ module API
         end
 
         def metadata_param
-          params.require(:metadata).permit!
+          params.fetch(:metadata, {}).permit!
         end
     end
   end

--- a/app/controllers/api/v3/instances_controller.rb
+++ b/app/controllers/api/v3/instances_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module API
+  module V3
+    class InstancesController < APIController
+      before_action :get_exercise, :authorize_spec, :validate_id, :validate_params
+
+      def update
+        datum = spec.instance_metadata.first_or_create(instance: params[:id])
+        if datum && datum.update(
+          metadata: if request.patch?
+                      datum.metadata.merge(metadata_param)
+                    else
+                      metadata_param
+                    end
+        )
+          render json: { result: datum }
+        else
+          render_error(message: 'Saving metadata failed!')
+        end
+      rescue ActiveRecord::RecordNotFound
+        render_not_found
+      end
+
+      private
+        def spec
+          @spec ||= policy_scope(@exercise.customization_specs)
+            .for_api
+            .friendly.find(params[:customization_spec_id])
+        end
+
+        def authorize_spec
+          authorize(spec, :update?)
+        end
+
+        def validate_id
+          return if valid_instance_ids.include?(params[:id])
+          render_not_found
+        end
+
+        def valid_instance_ids
+          CustomizationSpecPresenter.new(spec).as_json[:instances].map { _1[:id] }
+        end
+
+        def validate_params
+          return if params[:metadata].is_a? ActionController::Parameters
+          render_error(status: 400, message: 'Metadata must be a dictionary!')
+        end
+
+        def metadata_param
+          params.require(:metadata).permit!
+        end
+    end
+  end
+end

--- a/app/models/customization_spec.rb
+++ b/app/models/customization_spec.rb
@@ -72,10 +72,10 @@ class CustomizationSpec < ApplicationRecord
     end
   end
 
-  def deployable_instances(presenter = API::V3::InstancePresenter)
+  def deployable_instances(presenter = API::V3::InstancePresenter, **opts)
     (team_numbers || [nil]).product(sequential_numbers || [nil])
       .map do |team_number, sequential_number|
-        presenter.new(self, sequential_number, team_number)
+        presenter.new(self, sequential_number, team_number, **opts)
       end
   end
 

--- a/app/models/customization_spec.rb
+++ b/app/models/customization_spec.rb
@@ -36,6 +36,7 @@ class CustomizationSpec < ApplicationRecord
   has_one :exercise, through: :virtual_machine
   has_and_belongs_to_many :capabilities,
     after_add: :invalidate_capability_cache, after_remove: :invalidate_capability_cache
+  has_many :instance_metadata, dependent: :destroy
 
   validates :name, uniqueness: { scope: :virtual_machine }, presence: true, length: { minimum: 1, maximum: 63 }, hostname: true
   validates :dns_name, length: { minimum: 1, maximum: 63, allow_blank: true }, hostname: { allow_blank: true }

--- a/app/models/instance_metadatum.rb
+++ b/app/models/instance_metadatum.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class InstanceMetadatum < ApplicationRecord
+  belongs_to :customization_spec
+end

--- a/app/presenters/api/v3/customization_spec_presenter.rb
+++ b/app/presenters/api/v3/customization_spec_presenter.rb
@@ -2,7 +2,14 @@
 
 module API
   module V3
-    class CustomizationSpecPresenter < Struct.new(:spec)
+    class CustomizationSpecPresenter
+      attr_reader :spec, :options
+
+      def initialize(spec, **opts)
+        @spec = spec
+        @options = opts
+      end
+
       def as_json(_opts = nil)
         Rails.cache.fetch(cache_key) do
           preload_interfaces
@@ -45,7 +52,9 @@ module API
             vm.actor&.root&.cache_key_with_version,
             'numbering',
             vm.numbered_actor&.cache_key_with_version,
-            vm.numbered_actor&.root&.cache_key_with_version
+            vm.numbered_actor&.root&.cache_key_with_version,
+            options[:include_metadata] ? 'metadata' : nil,
+            options[:include_metadata] ? spec.instance_metadata.cache_key_with_version : nil
           ].compact
         end
 
@@ -78,7 +87,7 @@ module API
         end
 
         def instances
-          spec.deployable_instances(InstancePresenter).filter_map(&:as_json)
+          spec.deployable_instances(InstancePresenter, **options).filter_map(&:as_json)
         end
 
         def capabilities

--- a/app/presenters/api/v3/instance_presenter.rb
+++ b/app/presenters/api/v3/instance_presenter.rb
@@ -2,8 +2,16 @@
 
 module API
   module V3
-    class InstancePresenter < Struct.new(:spec, :sequential_number, :team_number)
+    class InstancePresenter
+      attr_reader :spec, :sequential_number, :team_number, :options
       delegate :operating_system, to: :vm
+
+      def initialize(spec, sequential_number = nil, team_number = nil, **opts)
+        @spec = spec
+        @sequential_number = sequential_number
+        @team_number = team_number
+        @options = opts
+      end
 
       def as_json
         return if skip_by_numbering
@@ -24,7 +32,7 @@ module API
           checks:,
           tags:,
           config_map: {}
-        }.merge(team_numbers).merge(sequence_info)
+        }.merge(team_numbers).merge(sequence_info).merge(metadata)
       end
 
       private
@@ -75,6 +83,13 @@ module API
           {
             team_nr: team_number,
             team_nr_str: team_number.to_s.rjust(2, '0'),
+          }
+        end
+
+        def metadata
+          return {} unless options[:include_metadata]
+          {
+            metadata: spec.instance_metadata.select(:metadata).find_by(instance: inventory_name)&.metadata
           }
         end
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,29 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "b9640f0b578ce0f42fa22029cc34707b93042782595f423412420f9481c44bc7",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/api/v3/instances_controller.rb",
+      "line": 51,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.fetch(:metadata, {}).permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "API::V3::InstancesController",
+        "method": "metadata_param"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ],
+      "note": "We are explicitly storing custom user generated fields here"
+    }
+  ],
+  "updated": "2024-03-25 10:45:32 +0000",
+  "brakeman_version": "6.1.2"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,9 @@ Rails.application.routes.draw do
         resources :tags, only: %i[index]
         resource :inventory, only: %i[show]
         resource :graph, only: %i[show]
-        resources :customization_specs, path: 'hosts', only: %i[index show]
+        resources :customization_specs, path: 'hosts', only: %i[index show] do
+          resources :instances, only: %i[update]
+        end
         resources :actors, only: %i[index]
       end
     end

--- a/db/migrate/20240322130758_create_instance_metadata.rb
+++ b/db/migrate/20240322130758_create_instance_metadata.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateInstanceMetadata < ActiveRecord::Migration[7.1]
+  def change
+    create_table :instance_metadata do |t|
+      t.references :customization_spec, null: false, foreign_key: true
+      t.string :instance, null: false
+      t.jsonb :metadata, default: {}, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_08_25_085618) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_22_130758) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -171,6 +171,15 @@ ActiveRecord::Schema[7.1].define(version: 2023_08_25_085618) do
     t.string "local_admin_resource_name"
     t.index ["abbreviation"], name: "index_exercises_on_abbreviation", unique: true
     t.index ["slug"], name: "index_exercises_on_slug", unique: true
+  end
+
+  create_table "instance_metadata", force: :cascade do |t|
+    t.bigint "customization_spec_id", null: false
+    t.string "instance", null: false
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customization_spec_id"], name: "index_instance_metadata_on_customization_spec_id"
   end
 
   create_table "network_interfaces", force: :cascade do |t|
@@ -366,6 +375,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_08_25_085618) do
   add_foreign_key "capabilities", "exercises"
   add_foreign_key "checks", "services"
   add_foreign_key "customization_specs", "virtual_machines"
+  add_foreign_key "instance_metadata", "customization_specs"
   add_foreign_key "network_interfaces", "networks"
   add_foreign_key "network_interfaces", "virtual_machines"
   add_foreign_key "networks", "actors"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -100,4 +100,10 @@ FactoryBot.define do
   factory :service_subject do
     service
   end
+
+  factory :instance_metadatum do
+    customization_spec { nil }
+    instance { 'MyString' }
+    metadata { '' }
+  end
 end

--- a/spec/models/customization_spec_spec.rb
+++ b/spec/models/customization_spec_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe CustomizationSpec do
       expect(subject.first.sequential_number).to eq nil
     end
 
+    context 'with kwargs' do
+      subject { spec.deployable_instances(presenter, moo: 123) }
+
+      it 'should pass kwargs to presenter' do
+        expect(presenter).to receive(:new).with(spec, nil, nil, moo: 123)
+        subject
+      end
+    end
+
     context 'with custom_instance_count on vm' do
       let(:spec) { build(:customization_spec, virtual_machine:) }
       let(:virtual_machine) { build(:virtual_machine, custom_instance_count: count) }

--- a/spec/presenters/customization_spec_presenter_spec.rb
+++ b/spec/presenters/customization_spec_presenter_spec.rb
@@ -55,4 +55,18 @@ RSpec.describe API::V3::CustomizationSpecPresenter do
       end
     end
   end
+
+  context 'options' do
+    subject { described_class.new(spec, include_metadata: true) }
+
+    it 'should include metadata in cache key' do
+      expect(subject.send(:cache_key)).to include('metadata')
+      expect(subject.send(:cache_key)).to include(spec.instance_metadata.cache_key_with_version)
+    end
+
+    it 'should call instance presenter with include_metadata option' do
+      expect(spec).to receive(:deployable_instances).with(API::V3::InstancePresenter, include_metadata: true).and_return([])
+      subject.as_json
+    end
+  end
 end

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe API::V3::InstancePresenter do
+  let(:virtual_machine) { create(:virtual_machine) }
+  let(:spec) { virtual_machine.host_spec }
+
+  let(:team_nr) { nil }
+  let(:seq_nr) { nil }
+  let(:opts) { nil }
+
+  subject { described_class.new(spec, team_nr, seq_nr, **opts) }
+
+  before {
+    Current.interfaces_cache ||= {}
+    Current.interfaces_cache[virtual_machine.id] ||= virtual_machine.network_interfaces.for_api.load_async
+  }
+
+  context 'with include_metadata' do
+    let!(:existing_meta) { create(:instance_metadatum, instance: 'doesnotmatter', customization_spec: virtual_machine.host_spec, metadata: { 'my' => 'stuff' }) }
+    let(:opts) { { include_metadata: true } }
+
+    it 'should include metadata' do
+      expect(subject).to receive(:inventory_name).at_least(:once).and_return 'doesnotmatter'
+      expect(subject.as_json[:metadata]).to eq({
+        'my' => 'stuff'
+      })
+    end
+
+    it 'should not include for mismatching instance id' do
+      expect(subject.as_json[:metadata]).to eq(nil)
+    end
+  end
+end

--- a/spec/requests/api_v3_hosts_spec.rb
+++ b/spec/requests/api_v3_hosts_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API v3 hosts', type: :request do
+  let(:exercise) { create(:exercise) }
+
+  let!(:user) { create(:user, api_tokens: [api_token], permissions: Hash[exercise.id, ['local_admin']]) }
+  let(:api_token) { create(:api_token) }
+  let(:headers) { { 'Accept' => 'application/json', 'Authorization' => "Token #{api_token.token}" } }
+
+  context 'metadata update' do
+    let!(:virtual_machine) { create(:virtual_machine, exercise:, actor: exercise.actors.sample) }
+    let(:presenter) { API::V3::InstancePresenter.new(virtual_machine.host_spec) }
+    let(:instance_id) { presenter.send(:inventory_name) }
+    let(:headers) {
+      {
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+        'Authorization' => "Token #{api_token.token}"
+      }
+    }
+    let(:params) {
+      {
+        some: 'Variable',
+        time: Time.parse('2024-03-20 14:00:00Z'),
+        number: 2
+      }
+    }
+    let(:url) { "/api/v3/#{exercise.slug}/hosts/#{virtual_machine.host_spec.slug}/instances/#{instance_id}/" }
+    let(:request_method) { :put }
+
+    subject(:do_request) {
+      public_send(request_method, url, params: { metadata: params }.to_json, headers:)
+    }
+    subject { do_request; response }
+
+    let!(:existing_meta) { create(:instance_metadatum, instance: instance_id, customization_spec: virtual_machine.host_spec, metadata: { 'my' => 'stuff' }) }
+
+    context 'invalid urls - spec cannot be found' do
+      let(:url) { "/api/v3/#{exercise.slug}/hosts/randomness/instances/#{instance_id}/" }
+
+      it { is_expected.to have_http_status 404 }
+    end
+
+    context 'invalid urls - instance cannot be found' do
+      let(:url) { "/api/v3/#{exercise.slug}/hosts/#{virtual_machine.host_spec.slug}/instances/randominstance/" }
+
+      it { is_expected.to have_http_status 404 }
+    end
+
+    context 'invalid payload - empty' do
+      subject { public_send(request_method, url, headers:); response }
+
+      it { is_expected.to have_http_status 400 }
+    end
+
+    context 'invalid payload - array' do
+      let(:params) { %w(asd asd2) }
+
+      it { is_expected.to have_http_status 400 }
+    end
+
+    context 'invalid payload - string' do
+      let(:params) { 'asd' }
+
+      it { is_expected.to have_http_status 400 }
+    end
+
+    context 'invalid payload - number' do
+      let(:params) { 3 }
+
+      it { is_expected.to have_http_status 400 }
+    end
+
+    context 'Full update' do
+      it { is_expected.to be_successful }
+
+      it 'should replace previous metadata with payload' do
+        subject
+        expect(response.parsed_body).to have_key('result')
+        expect(virtual_machine.host_spec.instance_metadata.find_by(instance: instance_id).metadata).to eq({
+          'some' => 'Variable',
+          'time' => '2024-03-20T14:00:00.000Z',
+          'number' => 2
+        })
+      end
+
+      it 'should not change timestamp of spec when updating' do
+        initial_updated_at = CustomizationSpec.find(virtual_machine.host_spec.id).updated_at
+        subject
+        after_updated_at = CustomizationSpec.find(virtual_machine.host_spec.id).updated_at
+        expect(initial_updated_at).to eq(after_updated_at)
+      end
+    end
+
+    context 'Partial update' do
+      let(:request_method) { :patch }
+
+      it { is_expected.to be_successful }
+
+      it 'should merge the payload with previous data' do
+        subject
+        expect(response.parsed_body).to have_key('result')
+        expect(virtual_machine.host_spec.instance_metadata.find_by(instance: instance_id).metadata).to eq(
+          {
+            'some' => 'Variable',
+            'time' => '2024-03-20T14:00:00.000Z',
+            'number' => 2,
+            'my' => 'stuff'
+          }
+        )
+      end
+
+      it 'should not change timestamp of spec when updating' do
+        initial_updated_at = CustomizationSpec.find(virtual_machine.host_spec.id).updated_at
+        subject
+        after_updated_at = CustomizationSpec.find(virtual_machine.host_spec.id).updated_at
+        expect(initial_updated_at).to eq(after_updated_at)
+      end
+    end
+
+    context 'Partial update - from empty state' do
+      let!(:existing_meta) { nil }
+      let(:request_method) { :patch }
+      it { is_expected.to be_successful }
+
+      it 'should merge the payload with previous data' do
+        subject
+        expect(response.parsed_body).to have_key('result')
+        expect(virtual_machine.host_spec.instance_metadata.find_by(instance: instance_id).metadata).to eq(
+          {
+            'some' => 'Variable',
+            'time' => '2024-03-20T14:00:00.000Z',
+            'number' => 2
+          }
+        )
+      end
+
+      it 'should not change timestamp of spec when updating' do
+        initial_updated_at = CustomizationSpec.find(virtual_machine.host_spec.id).updated_at
+        subject
+        after_updated_at = CustomizationSpec.find(virtual_machine.host_spec.id).updated_at
+        expect(initial_updated_at).to eq(after_updated_at)
+      end
+    end
+  end
+end

--- a/spec/requests/api_v3_hosts_spec.rb
+++ b/spec/requests/api_v3_hosts_spec.rb
@@ -94,6 +94,18 @@ RSpec.describe 'API v3 hosts', type: :request do
       end
     end
 
+    context 'with empty dict as param' do
+      let(:params) { {} }
+
+      it { is_expected.to be_successful }
+
+      it 'should replace previous metadata with payload' do
+        subject
+        expect(response.parsed_body).to have_key('result')
+        expect(virtual_machine.host_spec.instance_metadata.find_by(instance: instance_id).metadata).to eq({})
+      end
+    end
+
     context 'Partial update' do
       let(:request_method) { :patch }
 


### PR DESCRIPTION
Add a writable metadata endpoint for instances, designed for storing post-deploy metadata about systems.

To avoid cache thrashing of inventory endpoint, metadata can only be read by directly query-ing hosts endpoint.

This API is experimental and its URL-s and shape might change

- **feat: Add instance metadata model**
- **feat: Add keyword passing the spec presenter**
- **feat: Add instance metadata to hosts API**
