### PR TITLE
refactor: Tags generation

### DIFF
--- a/app/calculation/generate_tags.rb
+++ b/app/calculation/generate_tags.rb
@@ -1,187 +1,102 @@
 # frozen_string_literal: true
 
 class GenerateTags < Patterns::Calculation
+  ApiTag = Data.define(:id, :name, :config_map, :priority) do
+    def initialize(id:, name: nil, config_map: {}, priority:)
+      super(id:, name: name || id, config_map:, priority:)
+    end
+  end
+
+  CustomizationContainer = Data.define
+  MultiContainer = Data.define(:spec)
+  AllSpecs = Data.define(:virtual_machine)
+  ActorWithNumber = Data.define(:actor, :number)
+  NumberedByAnotherActor = Data.define(:actor, :numbered_actor, :number) do
+    def initialize(actor:, numbered_actor:, number: nil)
+      super(actor:, numbered_actor:, number:)
+    end
+  end
+
+  attr_reader :tag_sources
+
   private
     def result
-      case subject
-      when OperatingSystem
-        os_result
-      when Actor
-        actor_result
-      when Network
-        network_result
-      when VirtualMachine
-        virtual_machine_result
-      when CustomizationSpec
-        spec_result
-      when Capability
-        capability_result
-      when API::V3::InstancePresenter
-        api_instance_result || []
+      @tag_sources = Set.new
+      resolve_inputs
+      tags_from_tag_sources
+    end
+
+    def resolve_inputs(item = subject)
+      case item
       when Enumerable
-        subject.map { |item| self.class.result_for(item, options) }.flatten
-      else
-        []
-      end.flatten.compact
-    end
-
-    def os_result
-      [{
-        id: subject.api_short_name,
-        name: subject.name,
-        config_map: {},
-        children: [],
-        priority: 10 + subject.depth
-      }]
-    end
-
-    def actor_result
-      [
-        {
-          id: ActorAPIName.result_for(subject),
-          name: subject.name,
-          config_map: {},
-          children: [],
-          priority: 30 + subject.depth * 3
-        },
-        numbered_actors,
-        actors_as_numbered_for_vms
-      ].reject(&:blank?)
-    end
-
-    def numbered_actors
-      return [] if options[:spec] || !subject.root.number?
-      subject.root.all_numbers.map do |number|
-        configs = subject
-          .root
-          .actor_number_configs
-          .for_number(number)
-        {
-          id: ActorAPIName.result_for(subject, number:),
-          name: "#{subject.name} number #{number}",
-          config_map: configs.map(&:config_map).reduce(&:merge) || {},
-          children: [],
-          priority: 31 + subject.depth * 3
-        }
+        item.compact.each { resolve_inputs(_1) }
+      when API::V3::CustomizationSpecPresenter
+        resolve_inputs([
+          item.spec.virtual_machine.connection_nic&.network,
+          item.spec.virtual_machine.operating_system,
+          item.spec.virtual_machine.actor,
+          item.spec.virtual_machine,
+          item.spec,
+          item.spec.capabilities
+        ])
+      when API::V3::InstancePresenter
+        return if !item.team_number
+        actor = item.spec.virtual_machine.actor
+        numbered_actor = item.spec.virtual_machine.numbered_actor
+        if actor.path.include?(numbered_actor)
+          resolve_inputs(actor.path.map { ActorWithNumber.new(actor: _1, number: item.team_number) })
+        else
+          tag_sources.add NumberedByAnotherActor.new(actor:, numbered_actor:, number: item.team_number)
+        end
+      when Actor, OperatingSystem
+        item.path.each { tag_sources.add _1 }
+      when CustomizationSpec
+        tag_sources.add CustomizationContainer.new if item.mode_container?
+        tag_sources.add MultiContainer.new(item) if item.virtual_machine.clustered? || item.virtual_machine.numbered_by
+        resolve_inputs(item.tags)
+      when VirtualMachine
+        tag_sources.add AllSpecs.new(item) if item.customization_specs.size > 1
+        tag_sources.add NumberedByAnotherActor.new(actor: item.actor, numbered_actor: item.numbered_actor) if item.numbered_actor && !item.numbered_actor.subtree.include?(item.actor)
+      when Network, Capability, ActsAsTaggableOn::Tag, ActorWithNumber
+        tag_sources.add item
       end
     end
 
-    def actors_as_numbered_for_vms
-      return if options[:spec] # this is only needed if "overall" tags list is generated, not for specific spec
-      subject
-        .numbered_virtual_machines
-        .filter_map { |vm| vm.actor unless vm.actor.root == subject }
-        .uniq
-        .excluding(subject)
-        .map do |vm_actor|
-          children = subject.all_numbers.map do |number|
-            configs = subject
-              .actor_number_configs
-              .for_number(number)
-            {
-              id: ActorAPIName.result_for(vm_actor, numbered_by: subject, number:),
-              name: "#{vm_actor.name}, numbered by #{subject.name} - number #{number}",
-              config_map: configs.map(&:config_map).reduce(&:merge) || {},
-              children: [],
-              priority: 32 + vm_actor.depth * 3
-            }
-          end
-
-          [{
-            id: ActorAPIName.result_for(vm_actor, numbered_by: subject),
-            name: "#{vm_actor.name}, numbered by #{subject.name}",
-            config_map: {},
-            children: [],
-            priority: 32 + vm_actor.depth * 3
-          }] + children
+    def tags_from_tag_sources
+      tag_sources.filter_map do |item|
+        case item
+        when OperatingSystem
+          ApiTag.new(id: item.api_short_name, name: item.name, priority: 10 + item.depth)
+        when Capability
+          ApiTag.new(id: "capability_#{item.slug}".to_url.tr('-', '_'), name: item.name, priority: 20)
+        when Actor
+          ApiTag.new(id: ActorAPIName.result_for(item), name: item.name, priority: 30 + item.depth)
+        when ActorWithNumber
+          ApiTag.new(
+            id: ActorAPIName.result_for(item.actor, number: item.number),
+            name: "#{item.actor.name} number #{item.number}",
+            config_map: item.actor.actor_number_configs.for_number(item.number).pluck(:config_map).reduce(&:merge) || {},
+            priority: 31 + item.actor.depth * 3
+          )
+        when NumberedByAnotherActor
+          name = "#{item.actor.name}, numbered by #{item.numbered_actor.name}"
+          name += " - number #{item.number}" if item.number
+          ApiTag.new(
+            id: ActorAPIName.result_for(item.actor, numbered_by: item.numbered_actor, number: item.number),
+            name:,
+            priority: 32 + item.actor.depth * 3
+          )
+        when Network
+          ApiTag.new(id: item.api_short_name, name: item.name, priority: 80, config_map: { domain: item.full_domain })
+        when MultiContainer
+          ApiTag.new(id: item.spec.slug.tr('-', '_'), name: "All instances of #{item.spec.slug}", priority: 90)
+        when CustomizationContainer
+          ApiTag.new(id: 'customization_container', priority: 95)
+        when AllSpecs
+          ApiTag.new(id: "#{item.virtual_machine.name.tr('-', '_')}_all_specs", name: "All specs for #{item.virtual_machine.name}", priority: 95)
+        when ActsAsTaggableOn::Tag
+          ApiTag.new(id: "custom_#{item.name}", name: "Custom tag #{item.name}", priority: 100)
         end
-    end
-
-    def network_result
-      [{
-        id: subject.api_short_name,
-        name: subject.name,
-        config_map: {
-          domain: subject.full_domain
-        },
-        children: [],
-        priority: 80
-      }]
-    end
-
-    def virtual_machine_result
-      [].tap do |results|
-        if subject.numbered_actor && !subject.numbered_actor.subtree.include?(subject.actor)
-          results << {
-            id: ActorAPIName.result_for(subject.actor, numbered_by: subject.numbered_actor),
-            name: "#{subject.actor.name}, numbered by #{subject.numbered_actor.name}",
-            config_map: {},
-            children: [],
-            priority: 32 + subject.actor.depth * 3
-          }
-        end
-        if subject.customization_specs.size > 1
-          results << {
-            id: "#{subject.name.tr('-', '_')}_all_specs",
-            name: "All specs for #{subject.name}",
-            config_map: {},
-            children: [],
-            priority: 95
-          }
-        end
-      end
-    end
-
-    def spec_result
-      many_items = subject.virtual_machine.clustered? || subject.virtual_machine.numbered_actor
-      subject.tag_list.map do |custom_tag|
-        {
-          id: "custom_#{custom_tag}",
-          name: "Custom tag #{custom_tag}",
-          config_map: {},
-          children: [],
-          priority: 100
-        }
-      end + [
-        ({ id: subject.slug.tr('-', '_'), name: "All instances of #{subject.slug}", config_map: {}, children: [], priority: 90 } if many_items),
-        ({ id: 'customization_container', name: 'customization_container', config_map: {}, children: [], priority: 95 } if subject.mode_container?),
-      ]
-    end
-
-    def capability_result
-      [{
-        id: "capability_#{subject.slug}".to_url.tr('-', '_'),
-        name: subject.name,
-        config_map: {},
-        children: [],
-        priority: 20
-      }]
-    end
-
-    def api_instance_result
-      return if !subject.team_number
-
-      actor = subject.spec.virtual_machine.actor
-      nr_actor = subject.spec.virtual_machine.numbered_actor
-
-      if nr_actor.subtree.include?(actor)
-        actor.path.map do |node|
-          {
-            id: ActorAPIName.result_for(node, number: subject.team_number),
-            name: "#{node.name} number #{subject.team_number}",
-            config_map: {},
-            children: [],
-            priority: 31 + node.depth * 3
-          }
-        end
-      else
-        [{
-          id: ActorAPIName.result_for(actor, numbered_by: nr_actor, number: subject.team_number),
-          name: "#{actor.name}, numbered by #{nr_actor.name} - number #{subject.team_number}",
-          config_map: {},
-          children: [],
-          priority: 32 + actor.depth * 3
-        }]
       end
     end
 end

--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -3,7 +3,7 @@
 class Actor < ApplicationRecord
   has_ancestry
 
-  belongs_to :exercise
+  belongs_to :exercise, touch: true
 
   has_many :networks
   has_many :virtual_machines

--- a/app/presenters/api/v3/customization_spec_presenter.rb
+++ b/app/presenters/api/v3/customization_spec_presenter.rb
@@ -72,14 +72,7 @@ module API
         end
 
         def tags
-          GenerateTags.result_for([
-            Current.interfaces_cache[vm.id].detect(&:connection?)&.network,
-            vm.operating_system&.path,
-            vm.actor.path,
-            vm,
-            spec,
-            spec.capabilities
-          ], spec:).map { |tag_hash| tag_hash[:id] }
+          GenerateTags.result_for(self).map(&:id)
         end
 
         def services

--- a/app/presenters/api/v3/instance_presenter.rb
+++ b/app/presenters/api/v3/instance_presenter.rb
@@ -213,7 +213,7 @@ module API
         end
 
         def tags
-          GenerateTags.result_for(self).map { |tag| tag[:id] }
+          GenerateTags.result_for(self).map(&:id)
         end
 
         def connection_address

--- a/app/presenters/api/v3/tags_presenter.rb
+++ b/app/presenters/api/v3/tags_presenter.rb
@@ -4,62 +4,25 @@ module API
   module V3
     class TagsPresenter < Struct.new(:exercise, :scope)
       def as_json(_opts)
-        actor_tags + vm_tags + os_tags + zone_tags + capability_tags + spec_tags
+        Rails.cache.fetch(['apiv3', exercise.cache_key_with_version, 'spec_instance_tags', spec_scope.cache_key_with_version, vm_scope.cache_key_with_version]) do
+          GenerateTags.result_for(
+            spec_scope.all.map do |spec|
+              [
+                CustomizationSpecPresenter.new(spec),
+                spec.deployable_instances(InstancePresenter)
+              ]
+            end
+          )
+        end
       end
 
       private
-        def network_scope
-          # @network_scope ||= Pundit.policy_scope(scope, exercise.networks)
-          # temporarily show all networks in API
-          @network_scope ||= exercise.networks
-        end
-
         def spec_scope
           @spec_scope ||= Pundit.policy_scope(scope, exercise.customization_specs)
         end
 
         def vm_scope
           @vm_scope ||= Pundit.policy_scope(scope, exercise.virtual_machines)
-        end
-
-        def actor_scope
-          @actor_scope ||= Pundit.policy_scope(scope, exercise.actors)
-        end
-
-        def actor_tags
-          Rails.cache.fetch(['apiv3', exercise.cache_key_with_version, 'actors', actor_scope.cache_key_with_version]) do
-            GenerateTags.result_for(actor_scope.all)
-          end
-        end
-
-        def os_tags
-          Rails.cache.fetch(['apiv3', exercise.cache_key_with_version, 'os', OperatingSystem.all.cache_key_with_version]) do
-            GenerateTags.result_for(OperatingSystem.all)
-          end
-        end
-
-        def zone_tags
-          Rails.cache.fetch(['apiv3', exercise.cache_key_with_version, 'zone', network_scope.cache_key_with_version]) do
-            GenerateTags.result_for(network_scope.all)
-          end
-        end
-
-        def capability_tags
-          Rails.cache.fetch(['apiv3', exercise.cache_key_with_version, 'capability_list', exercise.capabilities.cache_key_with_version]) do
-            GenerateTags.result_for(exercise.capabilities.all)
-          end
-        end
-
-        def spec_tags
-          Rails.cache.fetch(['apiv3', exercise.cache_key_with_version, 'spec_tags', spec_scope.cache_key_with_version, vm_scope.cache_key_with_version]) do
-            GenerateTags.result_for(spec_scope.all).uniq
-          end
-        end
-
-        def vm_tags
-          Rails.cache.fetch(['apiv3', exercise.cache_key_with_version, 'vm_tags', vm_scope.cache_key_with_version]) do
-            GenerateTags.result_for(vm_scope.all).uniq
-          end
         end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
   factory :capability do
     sequence(:name) { |n| "Capability #{n}" }
     sequence(:slug) { |n| "capability#{n}" }
+    actor { exercise.actors.sample }
     exercise
   end
 
@@ -31,6 +32,7 @@ FactoryBot.define do
   end
 
   factory :address_pool do
+    name { 'Pool' }
     network
     network_address { '1.2.3.0/24' }
   end


### PR DESCRIPTION
Only output tags that are on generated instances: this avoids sync
problems between tags endpoint and inventory
