### PR TITLE
Owners for CustomizationSpecs

### DIFF
--- a/app/controllers/customization_specs_controller.rb
+++ b/app/controllers/customization_specs_controller.rb
@@ -5,20 +5,21 @@ class CustomizationSpecsController < ApplicationController
   before_action :get_exercise, :get_virtual_machine
   before_action :preload_form_collections, :preload_services, only: %i[create update]
   before_action :get_customization_spec, only: %i[update destroy]
-  before_action :get_and_verify_capability_ids, only: %i[update]
+  before_action :get_and_verify_capability_ids, :get_and_verify_user_id, only: %i[update]
 
   respond_to :turbo_stream
 
   def create
     @customization_spec = @virtual_machine
       .customization_specs
-      .create(mode: 'container', name: "spec-#{@virtual_machine.customization_specs.size}")
+      .create(mode: 'container', name: "spec-#{@virtual_machine.customization_specs.size}", user: current_user)
     authorize! @customization_spec
   end
 
   def update
     preload_services
     @customization_spec.assign_attributes(spec_params)
+    @customization_spec.user = @permitted_user || @customization_spec.user
     @customization_spec.capability_ids = @permitted_capability_ids
     @customization_spec.save
   end
@@ -48,5 +49,11 @@ class CustomizationSpecsController < ApplicationController
       @permitted_capability_ids = authorized_scope(@exercise.capabilities).where(
         id: params[:customization_spec].extract!(:capability_ids)[:capability_ids]
       ).pluck(:id)
+    end
+
+    def get_and_verify_user_id
+      @permitted_user = authorized_scope(User.all)
+        .join_role_bindings
+        .find_by(role_bindings: { exercise_id: @exercise.id }, id: params[:customization_spec].extract!(:user_id)[:user_id])
     end
 end

--- a/app/controllers/virtual_machines_controller.rb
+++ b/app/controllers/virtual_machines_controller.rb
@@ -35,6 +35,7 @@ class VirtualMachinesController < ApplicationController
       params.require(:virtual_machine).permit(:name)
     )
     @virtual_machine.actor = @submitted_actor
+    @virtual_machine.system_owner = current_user
     authorize! @virtual_machine
 
     if @virtual_machine.save

--- a/app/models/customization_spec.rb
+++ b/app/models/customization_spec.rb
@@ -30,6 +30,7 @@ class CustomizationSpec < ApplicationRecord
   }
 
   belongs_to :virtual_machine, touch: true
+  belongs_to :user
   has_one :exercise, through: :virtual_machine
   has_and_belongs_to_many :capabilities,
     after_add: :invalidate_capability_cache, after_remove: :invalidate_capability_cache

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   has_many :owned_systems, class_name: 'VirtualMachine', foreign_key: :system_owner_id
+  has_many :customization_specs
   has_many :api_tokens
 
   devise :trackable, :omniauthable, omniauth_providers: %i[sso]

--- a/app/models/virtual_machine.rb
+++ b/app/models/virtual_machine.rb
@@ -164,7 +164,7 @@ class VirtualMachine < ApplicationRecord
     end
 
     def create_default_spec
-      customization_specs.first_or_create(mode: 'host', name:)
+      customization_specs.first_or_create(mode: 'host', name:, user: system_owner)
     end
 
     def forced_numbered_by

--- a/app/presenters/api/v3/customization_spec_presenter.rb
+++ b/app/presenters/api/v3/customization_spec_presenter.rb
@@ -17,7 +17,7 @@ module API
             id: spec.slug,
             spec_name: spec.name.to_url,
             customization_context: spec.mode,
-            owner: vm.system_owner&.name,
+            owner: (spec.user || vm.system_owner)&.name,
             description: spec.mode_host? ? vm.description : spec.description,
             role: spec.role,
             actor_id: vm.actor.abbreviation,

--- a/app/views/customization_specs/_customization_spec.html.haml
+++ b/app/views/customization_specs/_customization_spec.html.haml
@@ -48,13 +48,14 @@
           - if customization_spec.errors[:dns_name].any?
             %span.text-red-600= customization_spec.errors[:dns_name].join(', ')
 
+      .mt-2
+        = form.label :user_id, for: "customization_spec#{customization_spec.id}_user", class: 'block font-bold text-gray-700 dark:text-gray-200'
+        = form.collection_select :user_id, @system_owners, :id, :name, {}, data: { controller: 'select' }, disabled: !allowed_to?(:update?, @virtual_machine)
 
-        - if customization_spec.mode_container?
-          .h-0.basis-full
-
-          .grow
-            = form.label :description, for: "customization_spec#{customization_spec.id}_description", class: 'block font-bold text-gray-700 dark:text-gray-200'
-            = form.text_area :description, id: "customization_spec#{customization_spec.id}_description", class: 'form-input', data: { controller: "textarea-autogrow" }
+      - if customization_spec.mode_container?
+        .mt-2
+          = form.label :description, for: "customization_spec#{customization_spec.id}_description", class: 'block font-bold text-gray-700 dark:text-gray-200'
+          = form.text_area :description, id: "customization_spec#{customization_spec.id}_description", class: 'form-input', data: { controller: "textarea-autogrow" }
 
       .mt-2
         = form.label :capability_ids, Capability.model_name.human.pluralize, for: "customization_spec#{customization_spec.id}_capability_ids", class: 'block font-bold text-gray-700 dark:text-gray-200'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
       address_pool:
         mode: IP family
       customization_spec:
+        user_id: Owner
         api_id: Instance ID in API
         role_name: Customization role name
         dns_name: DNS name

--- a/db/data/20250217085238_add_owners_to_specs.rb
+++ b/db/data/20250217085238_add_owners_to_specs.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddOwnersToSpecs < ActiveRecord::Migration[8.0]
+  def up
+    CustomizationSpec.find_each do |spec|
+      spec.update_columns(user_id: spec.virtual_machine.system_owner_id)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-DataMigrate::Data.define(version: 20241114081829)
+DataMigrate::Data.define(version: 20250217085238)

--- a/db/migrate/20250217085123_add_owner_to_customization_spec.rb
+++ b/db/migrate/20250217085123_add_owner_to_customization_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOwnerToCustomizationSpec < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :customization_specs, :user, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_15_104725) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_17_085123) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -170,7 +170,9 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_15_104725) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "cluster_mode", default: true
+    t.bigint "user_id"
     t.index ["name", "virtual_machine_id"], name: "index_customization_specs_on_name_and_virtual_machine_id", unique: true
+    t.index ["user_id"], name: "index_customization_specs_on_user_id"
     t.index ["virtual_machine_id"], name: "index_customization_specs_on_virtual_machine_id"
   end
 
@@ -386,6 +388,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_15_104725) do
   add_foreign_key "credential_sets", "exercises"
   add_foreign_key "credential_sets", "networks"
   add_foreign_key "credentials", "credential_sets"
+  add_foreign_key "customization_specs", "users"
   add_foreign_key "customization_specs", "virtual_machines"
   add_foreign_key "instance_metadata", "customization_specs"
   add_foreign_key "network_interfaces", "networks"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
 
   factory :customization_spec do
     virtual_machine
+    user
     mode { 'host' }
     sequence(:name) { |n| "CoolSpec#{n}" }
     role_name { 'MyString' }
@@ -55,6 +56,7 @@ FactoryBot.define do
 
   factory :virtual_machine do
     sequence(:name) { |n| "CoolTarget#{n}" }
+    association :system_owner, factory: :user
     actor
     operating_system
     exercise


### PR DESCRIPTION
Add owner field for `CustomizationSpec`-s, which is useful for hosts which are running multiple services managed by different owners

- **feat: Add user_id column to CustomizationSpecs table**
- **feat: Add user_id logic, API and UI to CustomizationSpecs**
