### PR TITLE
feat: Rework IPv6 special cases

### DIFF
--- a/app/components/address_special_chip_component.rb
+++ b/app/components/address_special_chip_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddressSpecialChipComponent < ViewComponent::Base
+  attr_reader :address
+
+  def initialize(address:)
+    @address = address
+  end
+
+  def render?
+    address.fixed? && address.special_range
+  end
+
+  def range_label
+    I18n.t("special_ranges.#{address.special_range}").presence || address.special_range.to_s.humanize
+  end
+end

--- a/app/components/address_special_chip_component/address_special_chip_component.html.haml
+++ b/app/components/address_special_chip_component/address_special_chip_component.html.haml
@@ -1,0 +1,1 @@
+%span.bg-purple-100.text-purple-800.text-xs.font-medium.me-2.px-2.5.py-0.5.rounded-sm.dark:bg-purple-900.dark:text-purple-300= range_label

--- a/app/views/addresses/_address.html.haml
+++ b/app/views/addresses/_address.html.haml
@@ -29,9 +29,9 @@
 
         .grow{data: {controller: 'tooltip', tooltip: 'Clear address'}}
           .flex
-            .grow
-              = form.label :offset, class: 'block font-bold text-gray-700 dark:text-gray-200', for: "#{dom_id(address)}_offset" do
-                = Address.human_attribute_name(:offset)
+            = form.label :offset, class: 'block font-bold text-gray-700 dark:text-gray-200', for: "#{dom_id(address)}_offset" do
+              = Address.human_attribute_name(:offset)
+            .grow.mx-2= render AddressSpecialChipComponent.new(address: address)
             - if address.fixed? && allowed_to?(:update?, address)
               %button.text-white.bg-linear-to-r.from-cyan-500.to-blue-500.hover:bg-linear-to-bl.focus:ring-4.focus:outline-hidden.focus:ring-cyan-300.dark:focus:ring-cyan-800.font-medium.rounded-lg.text-sm.px-2.text-center{class: "py-0", type: "submit", name: "address[randomize_address]", form: dom_id(address, :secondary)}
                 %i.fas.fa-dice
@@ -46,8 +46,8 @@
             - if address.address_pool.present? && address.address_pool.ip_network
               .mt-1= render IPPickerComponent.new(form: form, field: :offset, hosts: :all, label: false)
 
-          - when "ipv6_static", "ipv6_linklocal", "ipv6_uniqlocal", "ipv6_vip"
-            - if address.mode_ipv6_uniqlocal? || address.mode_ipv6_linklocal? || address.address_pool&.ip_network.present?
+          - when "ipv6_static", "ipv6_vip"
+            - if address.address_pool&.ip_network.present?
               = render SplitInputComponent.new do |split|
                 - split.with_left_cell do
                   = render LiquidAddressNetworkSansPrefixComponent.new(object: address)

--- a/app/views/networks/_used_addresses.html.haml
+++ b/app/views/networks/_used_addresses.html.haml
@@ -15,6 +15,7 @@
             .block
               - if address.offset
                 = render LiquidAddressComponent.new(object: address)
+                = render AddressSpecialChipComponent.new(address: address)
                 - if address.vip?
                   %span.text-xs.rounded-full.mx-1.py-1.px-2.bg-cyan-100.text-cyan-500 Virtual IP
                 - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,8 +84,6 @@ en:
     ipv6_static: IPv6 static
     ipv6_slaac: IPv6 SLAAC
     ipv6_dhcp: IPv6 DHCPv6
-    ipv6_linklocal: IPv6 link-local
-    ipv6_uniqlocal: IPv6 unique local
     ipv4_vip: IPv4 virtual
     ipv6_vip: IPv6 virtual
 
@@ -111,6 +109,10 @@ en:
     v6: IPv6
     ipv4: IPv4
     ipv6: IPv6
+
+  special_ranges:
+    link_local: Link-local
+    uniqlocal: Unique local
 
   service_subject_match_conditions:
     SpecMode: Spec mode


### PR DESCRIPTION
There is functionally little difference between configuring link-local,
ULA and static addresses.

This commit removes those special address cases, address pools with
correct ranges should be used instead.

Also adds badge when special range is detected
