### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -5,6 +5,8 @@
 # This workflow will install a prebuilt Ruby version, install dependencies, and
 # run tests and linters.
 name: "Ruby on Rails CI"
+permissions:
+  contents: read
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/ClarifiedSecurity/Providentia/security/code-scanning/2](https://github.com/ClarifiedSecurity/Providentia/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow YAML. The ideal spot is at the root level (above `jobs:`), which will apply the restrictions to all jobs unless overridden individually. This block should grant only the necessary privileges. For typical CI operations (checkout, dependencies, tests, lints) the minimal requirement is `contents: read`, which allows workflows to clone and read repository contents. No other elevated permissions are needed unless future tasks require them. 

Change details:
- Edit `.github/workflows/rubyonrails.yml`
- Insert a `permissions:` block immediately after the workflow `name:` and before the `on:` section.
- The block should be:

  ```yaml
  permissions:
    contents: read
  ```

No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
